### PR TITLE
feat(tools): benchmark profile-kwarg passthrough + full-pipeline timing

### DIFF
--- a/tests/test_tools_helpers.py
+++ b/tests/test_tools_helpers.py
@@ -30,8 +30,9 @@ def test_benchmark_profile_returns_timing_statistics():
 
     result = benchmark_profile(table, repeat=2, minimal=True)
 
-    assert set(result) == {"min_seconds", "mean_seconds", "max_seconds"}
+    assert set(result) == {"min_seconds", "median_seconds", "mean_seconds", "max_seconds"}
     assert 0 <= result["min_seconds"] <= result["mean_seconds"] <= result["max_seconds"]
+    assert result["min_seconds"] <= result["median_seconds"] <= result["max_seconds"]
 
 
 def test_render_report_writes_json(tmp_path):

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -14,20 +14,28 @@ from ibis_profiling import profile
 
 
 def benchmark_profile(
-    table: ibis.Table, *, repeat: int = 1, **profile_kwargs: Any
+    table: ibis.Table, *, repeat: int = 1, full: bool = False, **profile_kwargs: Any
 ) -> dict[str, float]:
-    """Profile a table repeatedly and return elapsed-time statistics."""
+    """Profile a table repeatedly and return elapsed-time statistics.
+
+    When ``full`` is True the timed region also serializes the report via ``to_dict()``
+    (finalize + render), measuring the whole pipeline rather than just query execution.
+    Extra keyword arguments are forwarded to ``profile`` (e.g. ``n_unique_threshold``).
+    """
     if repeat < 1:
         raise ValueError("repeat must be at least 1")
 
     durations = []
     for _ in range(repeat):
         started = time.perf_counter()
-        profile(table, **profile_kwargs)
+        report = profile(table, **profile_kwargs)
+        if full:
+            report.to_dict()
         durations.append(time.perf_counter() - started)
 
     return {
         "min_seconds": min(durations),
+        "median_seconds": statistics.median(durations),
         "mean_seconds": statistics.fmean(durations),
         "max_seconds": max(durations),
     }
@@ -38,12 +46,30 @@ def main() -> None:
     parser.add_argument("parquet")
     parser.add_argument("--repeat", type=int, default=1)
     parser.add_argument("--minimal", action="store_true")
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="also time report serialization (profile().to_dict()), not just query execution",
+    )
+    parser.add_argument(
+        "--kwarg",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="extra integer profile kwarg, repeatable (e.g. --kwarg n_unique_threshold=50000000)",
+    )
     args = parser.parse_args()
+
+    profile_kwargs: dict[str, Any] = {"minimal": args.minimal}
+    for item in args.kwarg:
+        key, _, value = item.partition("=")
+        profile_kwargs[key] = int(value)
 
     connection = ibis.duckdb.connect()
     table = connection.read_parquet(args.parquet)
-    result = benchmark_profile(table, repeat=args.repeat, minimal=args.minimal)
+    result = benchmark_profile(table, repeat=args.repeat, full=args.full, **profile_kwargs)
     print(json.dumps(result, indent=2))
+    print(f"kwargs: {profile_kwargs} full={args.full} repeat={args.repeat}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Extends `tools/benchmark.py`: `--kwarg KEY=VALUE` (int, repeatable, e.g. `n_unique_threshold`), `--full` (time `profile().to_dict()`), and `median_seconds` output. Reproduces the v0.1.24-vs-current perf comparison (2M×20): exact ~10.1s vs approx ~7.9s — no engine regression; the default delta is the finding-1 exact-n_unique accuracy default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)